### PR TITLE
Added Splunk UF integration + some enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ludus:
       - frack113.ludus_aurora_agent
 ```
 
-With custom configuration:
+With custom configuration and Splunk Attack Range integration:
 
 ```yaml
 ludus:
@@ -106,12 +106,13 @@ ludus:
     windows:
       install_additional_tools: true
     roles:
+      - p4t12ick.ludus_ar_windows
       - frack113.ludus_aurora_agent
     role_vars:
-      ludus_aurora_dashboard: true
-      ludus_aurora_config_preset: 'intense'
+      ludus_ar_windows_splunk_ip: "10.5.20.10"
       ludus_aurora_splunk_forwarder: true
       ludus_aurora_json_logging: true
+      ludus_aurora_dashboard: true
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Specifically this files folder:
 /opt/ludus/users/<your-ludus-username>/.ansible/roles/frack113.ludus_aurora_agent/files
 ```
 
-If using this role with Splunk, the [Aurora TA add-on](https://github.com/NextronSystems/TA-aurora) must be installed on the Splunk server to consume the EDR logs. 
+If using this role with Splunk, the [Aurora TA add-on](https://github.com/NextronSystems/TA-aurora) must be installed on the Splunk server to consume the EDR logs. It is also recommended to add `SHOULD_LINEMERGE = false` to the `nextron:aurora:edr` sourcetype to avoid parsing errors.
 
 ## Role Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,9 @@
 ludus_aurora_dashboard: false
 ludus_aurora_udp_target: ''
 ludus_aurora_udp_format: ''
+
+ludus_aurora_config_preset: 'standard'
+ludus_aurora_splunk_forwarder: false
+ludus_aurora_json_logging: false
+ludus_aurora_install_path: 'C:\Program Files\Aurora-Agent'
+ludus_aurora_log_path: 'C:\Program Files\Aurora-Agent\aurora_alerts.json.log'

--- a/files/README.md
+++ b/files/README.md
@@ -1,3 +1,0 @@
-Put files needed for the role here.
-Avoid putting large files (i.e. ISOs) here, instead download them.
-Avoid any proprietary software/files you are not authorized to distribute (i.e. Microsoft software), instead download them.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: restart aurora service
+  win_service:
+    name: Aurora Agent
+    state: restarted
+
+- name: restart splunk forwarder
+  win_service:
+    name: SplunkForwarder
+    state: restarted

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,25 +17,18 @@
     src: aurora-agent.lic
     dest: 'c:\aurora'
 
-# not find a better way for the dashboard :)
-# get an error with --dashboard option
+- name: Build aurora install command
+  ansible.builtin.set_fact:
+    aurora_install_cmd: >-
+      aurora-agent-64.exe --install
+      -c agent-config-{{ ludus_aurora_config_preset }}.yml
+      {{ '--dashboard' if ludus_aurora_dashboard else '' }}
+      {{ ('--json --logfile "' + ludus_aurora_log_path + '"') if ludus_aurora_json_logging else '' }}
+
 - name: Install aurora
   ansible.windows.win_command:
-    cmd: 'C:\aurora\aurora-agent-64.exe --install'
-
-- name: Copy Dashboard
-  ansible.windows.win_copy:
-    src: 'C:\aurora\tools'
-    dest: 'C:\Program Files\Aurora-Agent'
-    remote_src: true
-  when: ludus_aurora_dashboard
-
-- name: Add dashboard Run RegKey
-  ansible.windows.win_regedit:
-    path: 'HKLM:\SOFTWARE\Microsoft\windows\CurrentVersion\Run'
-    name: aurora-dashboard
-    data: 'C:\Program Files\Aurora-Agent\tools\aurora-dashboard.exe'
-  when: ludus_aurora_dashboard
+    cmd: '{{ aurora_install_cmd }}'
+    chdir: 'C:\aurora'
 
 - name: clean folder
   ansible.windows.win_file:

--- a/tasks/splunkuf.yml
+++ b/tasks/splunkuf.yml
@@ -1,0 +1,18 @@
+---
+- name: Check if Splunk Universal Forwarder is installed
+  ansible.windows.win_stat:
+    path: 'C:\Program Files\SplunkUniversalForwarder\etc\apps'
+  register: splunk_apps_path
+
+- name: Create aurora_agent_inputs_app directory structure
+  ansible.windows.win_file:
+    path: 'C:\Program Files\SplunkUniversalForwarder\etc\apps\aurora_agent_inputs_app\local'
+    state: directory
+  when: splunk_apps_path.stat.exists
+
+- name: Copy inputs.conf to Splunk Universal Forwarder
+  ansible.builtin.template:
+    src: inputs.conf.j2
+    dest: 'C:\Program Files\SplunkUniversalForwarder\etc\apps\aurora_agent_inputs_app\local\inputs.conf'
+  when: splunk_apps_path.stat.exists
+  notify: restart splunk forwarder

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -9,7 +9,7 @@
   ansible.windows.win_powershell:
     script: |
       Add-MpPreference -ExclusionPath c:\\aurora
-      Add-MpPreference -ExclusionPath "c:\\Program Files\\Aurora-Agent"
+      Add-MpPreference -ExclusionPath "{{ ludus_aurora_install_path }}"
   when: not service_aurora.exists
 
 - name: Install aurora as service
@@ -17,14 +17,24 @@
     file: install.yml
   when: not service_aurora.exists
 
-# we have aurora time to configure it
-- name: Copy the agent-config template to the host
+- name: Copy custom agent-config template for UDP logging
   ansible.builtin.template:
     src: agent-config.yml.j2
-    dest: 'C:\Program Files\Aurora-Agent\agent-config.yml'
+    dest: '{{ ludus_aurora_install_path }}\agent-config.yml'
+  when: ludus_aurora_udp_target != ''
 
-- name: Restart aurora service
-  win_service:
-    name: Aurora Agent
-    state: restarted
+- name: Add bginfo.exe exclusion to Aurora process excludes
+  community.windows.win_lineinfile:
+    path: '{{ ludus_aurora_install_path }}\config\process-excludes.cfg'
+    line: '{{ item }}'
+    insertafter: EOF
+    create: no
+  loop:
+    - '# Exclusion added by Ansible for Ludus, very noisy process'
+    - 'C:\\ludus\\background\\bginfo\.exe'
+  notify: restart aurora service
 
+- name: Configure Splunk Universal Forwarder
+  ansible.builtin.include_tasks:
+    file: splunkuf.yml
+  when: ludus_aurora_splunk_forwarder

--- a/templates/agent-config.yml.j2
+++ b/templates/agent-config.yml.j2
@@ -15,7 +15,7 @@ eventlog-format: ''
 # Write output as JSON instead of plain text
 json: false
 # Path to the directory containing the Aurora Agent license
-license-path: C:\Program Files\Aurora-Agent
+license-path: {{ ludus_aurora_install_path }}
 # Send logs to this UDP Address (as host:port)
 udp-target: '{{ ludus_aurora_udp_target }}'
 # Format for logs sent via UDP
@@ -61,7 +61,7 @@ print-event-id: false
 # Deactivate all consumers, except for those specified by --activate-module
 deactivate-all-consumers: false
 # Path to a file containing false positive regexes (one per line)
-false-positive-filter: C:\Program Files\Aurora-Agent\config\false-positives.cfg
+false-positive-filter: {{ ludus_aurora_install_path }}\config\false-positives.cfg
 # Generate a unique ID for this execution and print it with every log message
 scan-id: false
 # Send only the status messages to ASGARD, no matches
@@ -73,7 +73,7 @@ dev: false
 # Execute responses that are specified in Sigma rules (e.g. to kill a process)
 activate-responses: false
 # Folder where process dumps should be stored
-dump-folder: C:\Program Files\Aurora-Agent\process-dumps
+dump-folder: {{ ludus_aurora_install_path }}\process-dumps
 # Minimum average time between matches. Sigma Rules with responses will ignore this setting.
 match-throttling: 1m
 # Number of matches for a single rule that are allowed to exceed the throttling for a short time (see --match-throttling)
@@ -82,30 +82,30 @@ match-burst: 5
 scan-timeout: 1s
 # Folders containing IOC files
 ioc-path:
-    - C:\Program Files\Aurora-Agent\signatures\iocs
-    - C:\Program Files\Aurora-Agent\custom-signatures
+    - {{ ludus_aurora_install_path }}\signatures\iocs
+    - {{ ludus_aurora_install_path }}\custom-signatures
 # Report Sigma matches with rules of this level or higher (possible values: informational, low, medium, high, critical)
 minimum-level: medium
 # Folders containing the Sigma files
 rules-path:
-    - C:\Program Files\Aurora-Agent\signatures\sigma-rules
-    - C:\Program Files\Aurora-Agent\custom-signatures
+    - {{ ludus_aurora_install_path }}\signatures\sigma-rules
+    - {{ ludus_aurora_install_path }}\custom-signatures
 # Files containing responses for Sigma rules
 response-set: []
 # Paths to the Sigma log sources that should be loaded
 log-source:
-    - C:\Program Files\Aurora-Agent\log-sources\event-log-sources.yml
-    - C:\Program Files\Aurora-Agent\log-sources\etw-log-sources-standard.yml
-    - C:\Program Files\Aurora-Agent\log-sources\etw-log-source-mappings.yml
+    - {{ ludus_aurora_install_path }}\log-sources\event-log-sources.yml
+    - {{ ludus_aurora_install_path }}\log-sources\etw-log-sources-standard.yml
+    - {{ ludus_aurora_install_path }}\log-sources\etw-log-source-mappings.yml
 # Automatically reload the Sigma rules after changes
 auto-reload: false
 # Paths to file containing the information on which events IOCs should be applied
 ioc-config:
-    - C:\Program Files\Aurora-Agent\ioc-configs\ioc-config-standard.yml
+    - {{ ludus_aurora_install_path }}\ioc-configs\ioc-config-standard.yml
 # Deactivate calculations that rely on disk access (e.g. hash calculation for executables and DLLs)
 no-content-enrichment: false
 # Path to a file containing process exclusion regexes (one per line)
-process-excludes: C:\Program Files\Aurora-Agent\config\process-excludes.cfg
+process-excludes: {{ ludus_aurora_install_path }}\config\process-excludes.cfg
 # Path to a file where all events will be logged. Warning: This may cause high disk usage.
 audit-log: ''
 # Ignore events (by source, event ID and process) that use more processing time (as a percentage of total processing time) than this threshold. Set to 0 to disable automatic exclusion.

--- a/templates/inputs.conf.j2
+++ b/templates/inputs.conf.j2
@@ -1,0 +1,4 @@
+[monitor://{{ ludus_aurora_log_path }}]
+disabled = false
+sourcetype = nextron:aurora:edr
+index = win


### PR DESCRIPTION
Hello there! first of all, thanks for bringing Aurora to Ludus, it came in handy to build a Splunk AR lab in Ludus.

To make it easier to integrate Aurora with the Splunk Attack Range deployment, I have added some simple tasks to optionally configure JSON logging in Aurora and drop the required `inputs.conf` file on the host. 

I have also added variables to customize the install path, log directory, and config preset from the install package. If the user wants to use the UDP method for SIEM integration, the agent config template from the role is still being applied as before. 

I have tested a few deployments with success, the workflow being: deploy a Linux machine with `ludus_ar_splunk`, then a Windows host with both `ludus_ar_windows` + `ludus_aurora_agent`, add the Aurora TA to Splunk(not yet added automatically by the `ludus_ar_splunk` role), then enjoy the logs coming in Splunk.

Let me know what you think, is this too much? should I keep these changes in a fork? 

Peace and happy New Year!